### PR TITLE
Fix html-minifier issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A tool that allows you to compile static HTML templates so you could import them
 ## Installation
 
 ```bash
-meteor add static-html-compiler
+meteor add urigo:static-html-compiler
 ```
 
 If you are looking for a package with a working implementation of this tool you should check [`static-templates`](https://github.com/Urigo/meteor-static-templates).
@@ -18,7 +18,7 @@ import {
   TemplateHtmlCompiler, // templates
   StaticHtmlCompiler,
   utils,
-} from 'meteor/static-html-compiler';
+} from 'meteor/urigo:static-html-compiler';
 
 class TemplateCacheCompiler extends TemplateHtmlCompiler {
   compileContents(file, contents) {

--- a/package.js
+++ b/package.js
@@ -1,12 +1,13 @@
 Package.describe({
   name: 'urigo:static-html-compiler',
-  version: '0.0.1',
+  version: '0.0.2',
   summary: 'Compiles static HTML templates so you could import them from a module'
 });
 
 Npm.depends({
   'cheerio': '0.20.0',
-  'html-minifier': '2.1.2',
+  // XXX We should fix issue with 2+ version of html-minifier
+  'html-minifier': '0.8.0',
   'lodash.assign': '4.0.8'
 });
 
@@ -16,7 +17,7 @@ Package.onUse(function(api) {
   var packages = [
     'caching-compiler@1.0.0',
     'html-tools@1.0.5',
-    'ecmascript@0.1.6'
+    'ecmascript@0.2.0'
   ];
 
   api.use(packages, 'server');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "compile": "tsc",
     "lint": "tslint -e src/*.ts",
     "watch": "tsc -w",
-    "prepublish": "npm run compile"
+    "prepublish": "npm run compile",
+    "publish-meteor": "npm run prepublish && meteor publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To avoid spending too much time on it we can just switch to 0.8.0 version. With 1+ and the latest 2+ there is an issue when using with Meteor.
- README.md
- new version of this package (0.0.2)
- `publish-meteor` npm script to compile files and publish new version in one command

@Urigo I could merge it right now but need to know if you agree with me about switching (temporary) to an old working version of html-compiler. It's working locally but when you publish it to atmosphere it stops.
