### PR TITLE
Importing from node modules

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -639,290 +639,310 @@
       }
     },
     "html-minifier": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-2.1.2.tgz",
-      "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-2.1.2.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.8.0.tgz",
+      "from": "html-minifier@0.8.0",
       "dependencies": {
         "change-case": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
-          "from": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+          "from": "change-case@>=2.3.0 <2.4.0",
           "dependencies": {
             "camel-case": {
               "version": "1.2.2",
               "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
-              "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
+              "from": "camel-case@>=1.1.1 <2.0.0"
             },
             "constant-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+              "from": "constant-case@>=1.1.0 <2.0.0"
             },
             "dot-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
+              "from": "dot-case@>=1.1.0 <2.0.0"
             },
             "is-lower-case": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
-              "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+              "from": "is-lower-case@>=1.1.0 <2.0.0"
             },
             "is-upper-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+              "from": "is-upper-case@>=1.1.0 <2.0.0"
             },
             "lower-case": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz",
-              "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
+              "from": "lower-case@>=1.1.1 <2.0.0"
             },
             "lower-case-first": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
+              "from": "lower-case-first@>=1.0.0 <2.0.0"
             },
             "param-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
+              "from": "param-case@>=1.1.0 <2.0.0"
             },
             "pascal-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
+              "from": "pascal-case@>=1.1.0 <2.0.0"
             },
             "path-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
+              "from": "path-case@>=1.1.0 <2.0.0"
             },
             "sentence-case": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
-              "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
+              "from": "sentence-case@>=1.1.1 <2.0.0"
             },
             "snake-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
+              "from": "snake-case@>=1.1.0 <2.0.0"
             },
             "swap-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+              "from": "swap-case@>=1.1.0 <2.0.0"
             },
             "title-case": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
+              "from": "title-case@>=1.1.0 <2.0.0"
             },
             "upper-case": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-              "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+              "from": "upper-case@>=1.1.1 <2.0.0"
             },
             "upper-case-first": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
-              "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+              "from": "upper-case-first@>=1.1.0 <2.0.0"
             }
           }
         },
         "clean-css": {
-          "version": "3.4.12",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
-          "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
+          "version": "3.4.13",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.13.tgz",
+          "from": "clean-css@>=3.4.0 <3.5.0",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "from": "commander@>=2.8.0 <2.9.0",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                  "from": "graceful-readlink@>=1.0.0"
                 }
               }
             },
             "source-map": {
               "version": "0.4.4",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "from": "source-map@>=0.4.0 <0.5.0",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "from": "amdefine@>=0.0.4"
                 }
               }
             }
           }
         },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "cli": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.10.0.tgz",
+          "from": "cli@>=0.10.0 <0.11.0",
           "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            "exit": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "from": "exit@0.1.2"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "from": "glob@>=5.0.10 <6.0.0",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.4",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.1",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+                          "from": "balanced-match@>=0.4.1 <0.5.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                }
+              }
             }
           }
         },
-        "he": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/he/-/he-1.0.0.tgz",
-          "from": "https://registry.npmjs.org/he/-/he-1.0.0.tgz"
-        },
-        "ncname": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
-          "from": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+        "concat-stream": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+          "from": "concat-stream@>=1.5.0 <1.6.0",
           "dependencies": {
-            "xml-char-classes": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
-              "from": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0"
+            },
+            "readable-stream": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "from": "isarray@>=1.0.0 <1.1.0"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0"
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@>=0.0.5 <0.1.0"
             }
           }
         },
         "relateurl": {
           "version": "0.2.6",
           "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz",
-          "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
+          "from": "relateurl@>=0.2.0 <0.3.0"
         },
         "uglify-js": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+          "version": "2.4.24",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+          "from": "uglify-js@>=2.4.0 <2.5.0",
           "dependencies": {
             "async": {
               "version": "0.2.10",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "from": "async@>=0.2.6 <0.3.0"
             },
             "source-map": {
-              "version": "0.5.6",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+              "version": "0.1.34",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "from": "source-map@0.1.34",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
             },
             "yargs": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "version": "3.5.4",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "from": "yargs@>=3.5.4 <3.6.0",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "dependencies": {
-                    "center-align": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.4",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "3.0.3",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.3",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.4",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                            }
-                          }
-                        },
-                        "lazy-cache": {
-                          "version": "1.0.4",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-                        }
-                      }
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.4",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "3.0.3",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.3",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.4",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
+                  "from": "camelcase@>=1.0.2 <2.0.0"
                 },
                 "decamelize": {
                   "version": "1.2.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                  "from": "decamelize@>=1.0.0 <2.0.0"
                 },
                 "window-size": {
                   "version": "0.1.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "from": "window-size@0.1.0"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@0.0.2"
                 }
               }
             }
@@ -933,17 +953,17 @@
     "lodash.assign": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.8.tgz",
-      "from": "lodash.assign@4.0.8",
+      "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.8.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.6.tgz",
-          "from": "lodash.keys@>=4.0.0 <5.0.0"
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.6.tgz"
         },
         "lodash.rest": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.2.tgz",
-          "from": "lodash.rest@>=4.0.0 <5.0.0"
+          "from": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.2.tgz"
         }
       }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change log
+
+### vNEXT
+
+- Add support for files from node modules. [PR #6](https://github.com/Urigo/meteor-static-html-compiler/pull/6)
+
+### v0.0.4
+
+- Add support for html5 attributes. [PR #5](https://github.com/Urigo/meteor-static-html-compiler/pull/5)
+
+### v0.0.3
+
+- Fix body element attributes. [PR #3](https://github.com/Urigo/meteor-static-html-compiler/pull/3)
+
+### v0.0.2
+
+- Fix `html-minifier` issue. [PR #1](https://github.com/Urigo/meteor-static-html-compiler/pull/1)

--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -4,13 +4,114 @@ declare class CachingCompiler {
   public processFilesForTarget(file: any): any;
 }
 
-// from meteor/html-tools
-interface IHTMLTools {
-  parseFragment(src: string): string;
-}
-declare const HTMLTools: IHTMLTools;
-
 declare module 'lodash.assign' {
   import main = require('lodash');
   export = main.assign;
+}
+
+declare module 'html-minifier' {
+  import * as UglifyJS from 'uglify-js';
+  import * as CleanCSS from 'clean-css';
+  import * as RelateUrl from 'relateurl';
+
+  namespace HTMLMinifier {
+    function minify(text: string, options?: Options): string;
+
+    interface Options {
+      // Strip HTML comments
+      removeComments?: boolean;
+
+      // Strip HTML comments from scripts and styles
+      removeCommentsFromCDATA?: boolean;
+
+      // Remove CDATA sections from script and style elements
+      removeCDATASectionsFromCDATA?: boolean;
+
+      // Collapse white space that contributes to text nodes in a document tree
+      collapseWhitespace?: boolean;
+
+      // Always collapse to 1 space (never remove it entirely). Must be used in conjunction with collapseWhitespace=true
+      conservativeCollapse?: boolean;
+
+      // Don't leave any spaces between display:inline; elements when collapsing. Must be used in conjunction with collapseWhitespace=true
+      collapseInlineTagWhitespace?: boolean;
+
+      // Always collapse to 1 line break (never remove it entirely) when whitespace between tags include a line break. Must be used in conjunction with collapseWhitespace=true
+      preserveLineBreaks?: boolean;
+
+      // Omit attribute values from boolean attributes
+      collapseBooleanAttributes?: boolean;
+
+      // Remove quotes around attributes when possible
+      removeAttributeQuotes?: boolean;
+
+      // Remove attributes when value matches default
+      removeRedundantAttributes?: boolean;
+
+      // Prevents the escaping of the values of attributes.
+      preventAttributesEscaping?: boolean;
+
+      // Replaces the doctype with the short (HTML5) doctype
+      useShortDoctype?: boolean;
+
+      // Remove all attributes with whitespace-only values
+      removeEmptyAttributes?: boolean;
+
+      // Remove type="text/javascript" from script tags. Other type attribute values are left intact.
+      removeScriptTypeAttributes?: boolean;
+
+      // Remove type="text/css" from style and link tags. Other type attribute values are left intact.
+      removeStyleLinkTypeAttributes?: boolean;
+
+      // Remove unrequired tags
+      removeOptionalTags?: boolean;
+
+      // Remove all elements with empty contents
+      removeEmptyElements?: boolean;
+
+      // Toggle linting
+      lint?: boolean;
+
+      // Keep the trailing slash on singleton elements
+      keepClosingSlash?: boolean;
+
+      // Treat attributes in case sensitive manner (useful for custom HTML tags.)
+      caseSensitive?: boolean;
+
+      // Minify Javascript in script elements and on* attributes (uses UglifyJS)
+      minifyJS?: boolean | UglifyJS.MinifyOptions;
+
+      // Minify CSS in style elements and style attributes (uses clean-css)
+      minifyCSS?: boolean | CleanCSS.Options;
+
+      // Minify URLs in various attributes (uses relateurl)
+      minifyURLs?: boolean | RelateUrl.Options;
+
+      // Array of regex'es that allow to ignore certain comments, when matched
+      ignoreCustomComments?: Array<RegExp>;
+
+      // Array of regex'es that allow to ignore certain fragments, when matched (e.g. <?php ... ?>, {{ ... }}, etc.)
+      ignoreCustomFragments?: Array<RegExp>;
+
+      // Array of strings corresponding to types of script elements to process through minifier (e.g. text/ng-template, text/x-handlebars-template, etc.)
+      processScripts?: Array<string>;
+
+      // Specify a maximum line length. Compressed output will be split by newlines at valid HTML split-points
+      maxLineLength?: number;
+
+      // Arrays of regex'es that allow to support custom attribute assign expressions (e.g. '<div flex?="{{mode != cover}}"></div>')
+      customAttrAssign?: Array<RegExp>;
+
+      // Arrays of regex'es that allow to support custom attribute surround expressions (e.g. <input {{#if value}}checked="checked"{{/if}}>)
+      customAttrSurround?: Array<Array<RegExp>>;
+
+      // Regex that specifies custom attribute to strip newlines from (e.g. /ng\-class/)
+      customAttrCollapse?: RegExp;
+
+      // Type of quote to use for attribute values (' or ")
+      quoteCharacter?: string;
+    }
+  }
+
+  export = HTMLMinifier;
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,8 +1,3 @@
-import {
-  extend,
-  FileObject,
-} from './file';
-
 export interface IBaseHtmlCompiler {
   processFilesForTarget(files: any);
   compileResultSize(result): number;
@@ -22,8 +17,7 @@ export class BaseHtmlCompiler extends CachingCompiler {
     return file.getSourceHash();
   }
 
-  public processFilesForTarget(files: FileObject[]) {
-    files.forEach((file) => extend(file));
+  public processFilesForTarget(files) {
     super.processFilesForTarget(files);
   }
 };

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,3 +1,7 @@
+import {
+  FileObject,
+} from './file';
+
 export interface IBaseHtmlCompiler {
   processFilesForTarget(files: any);
   compileResultSize(result): number;
@@ -13,11 +17,11 @@ export class BaseHtmlCompiler extends CachingCompiler {
     });
   }
 
-  public getCacheKey(file): string {
+  public getCacheKey(file: FileObject): string {
     return file.getSourceHash();
   }
 
-  public processFilesForTarget(files) {
+  public processFilesForTarget(files: FileObject[]) {
     super.processFilesForTarget(files);
   }
 };

--- a/src/file.ts
+++ b/src/file.ts
@@ -8,7 +8,10 @@ export interface FileObject {
   getPackagePrefix(): string;
   getTemplateUrl(): string;
   getTemplateJS(): string;
+  getSourceHash(): string;
   isNodeModule(): boolean;
+  addHtml(options: any);
+  addJavaScript(options: any);
 }
 
 const fileMixin = {

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,11 +1,14 @@
 import assign = require('lodash.assign');
 
 export interface FileObject {
+  getContentsAsString(): string;
+  getBasename(): string;
   getPackageName(): string;
   getPathInPackage(): string;
   getPackagePrefix(): string;
   getTemplateUrl(): string;
   getTemplateJS(): string;
+  isNodeModule(): boolean;
 }
 
 const fileMixin = {
@@ -27,6 +30,12 @@ const fileMixin = {
    */
   getTemplateJS: function(): string {
     return `${this.getTemplateUrl()}.js`;
+  },
+  /**
+   * @return {boolean} checks if file comes from node module
+   */
+  isNodeModule: function(): boolean {
+    return !!this.getPathInPackage().startsWith('node_modules');
   },
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,10 @@ import {
   IBaseHtmlCompiler,
 } from './base';
 
+import {
+  FileObject,
+} from './file';
+
 import * as $ from 'cheerio';
 
 export interface Section {
@@ -24,7 +28,7 @@ export class MainHtmlCompiler extends BaseHtmlCompiler implements IBaseHtmlCompi
     return result.head.length + result.body.length;
   }
 
-  public compileOneFile(file): CompileResult {
+  public compileOneFile(file: FileObject): CompileResult {
     const $contents = $(file.getContentsAsString());
     const $head = $contents.closest('head');
     const $body = $contents.closest('body');
@@ -40,7 +44,7 @@ export class MainHtmlCompiler extends BaseHtmlCompiler implements IBaseHtmlCompi
     };
   }
 
-  public addCompileResult(file, result: CompileResult) {
+  public addCompileResult(file: FileObject, result: CompileResult) {
     try {
       file.addHtml({
         data: result.head.contents,

--- a/src/template.ts
+++ b/src/template.ts
@@ -4,6 +4,10 @@ import {
 } from './base';
 
 import {
+  FileObject,
+} from './file';
+
+import {
   minify,
   clean,
 } from './utils';
@@ -21,7 +25,7 @@ export class TemplateHtmlCompiler extends BaseHtmlCompiler implements ITemplateH
     return result.length;
   }
 
-  public compileOneFile(file): string {
+  public compileOneFile(file: FileObject): string {
     let compiled = undefined;
 
     try {
@@ -39,11 +43,11 @@ export class TemplateHtmlCompiler extends BaseHtmlCompiler implements ITemplateH
    * @param  {string} contents minified html
    * @return {string}          javascript code
    */
-  public compileContents(file, contents) {
+  public compileContents(file: FileObject, contents) {
     return `module.exports = "${clean(contents)}";`;
   }
 
-  public addCompileResult(file, result: string) {
+  public addCompileResult(file: FileObject, result: string) {
     const data = this.compileContents(file, result);
     const path = file.getPathInPackage();
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -22,7 +22,17 @@ export class TemplateHtmlCompiler extends BaseHtmlCompiler implements ITemplateH
   }
 
   public compileOneFile(file): string {
-    return minify(file.getContentsAsString());
+    let compiled = undefined;
+
+    try {
+      compiled = minify(file.getContentsAsString());
+    } catch (e) {
+      // throw an error only if file does not come from node module
+      if (!file.isNodeModule()) {
+        throw e;
+      }
+    }
+    return compiled;
   }
 
   /**
@@ -34,9 +44,12 @@ export class TemplateHtmlCompiler extends BaseHtmlCompiler implements ITemplateH
   }
 
   public addCompileResult(file, result: string) {
+    const data = this.compileContents(file, result);
+    const path = file.getPathInPackage();
+
     file.addJavaScript({
-      data: this.compileContents(file, result),
-      path: file.getPathInPackage(),
+      data,
+      path,
     });
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,6 @@
 import * as htmlMinifier from 'html-minifier';
 
 export function minify(html: string): string {
-  // Just parse the html to make sure it is correct before minifying
-  HTMLTools.parseFragment(html);
-
   return htmlMinifier.minify(html, {
     collapseWhitespace: true,
     conservativeCollapse: true,

--- a/typings.json
+++ b/typings.json
@@ -2,7 +2,6 @@
   "ambientDependencies": {
     "cheerio": "registry:dt/cheerio#0.17.0+20160407085313",
     "clean-css": "registry:dt/clean-css#3.4.9+20160316155526",
-    "html-minifier": "registry:dt/html-minifier#1.1.1+20160316155526",
     "lodash": "registry:dt/lodash#3.10.0+20160330154726",
     "relateurl": "registry:dt/relateurl#0.2.6+20160316155526",
     "source-map": "registry:dt/source-map#0.0.0+20160317120654",


### PR DESCRIPTION
It allows to import html files from node modules:

An example:

``` js
import template from 'angular-utils-pagination/dirPagination.tpl.html';
```

---
- Added **changelog**
- Removed **HTMLTools** (it was parsing the html to make sure it is correct before minifying, but we have `html-minifier` now)
- Moved File object extending to top-level class (StaticHtmlCompiler)
- Html file from node module will be interpreted only as **template**, not as main html
