### PR TITLE
Remove HTML comments in default settings

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ export function minify(html: string): string {
     minifyCSS: true,
     minifyJS: true,
     processScripts: ['text/template'],
+    removeComments: true
   });
 };
 


### PR DESCRIPTION
IMHO comments should be removed, when minifying HTML. Can be overwritten with #18.